### PR TITLE
@jinpark => Transform reset endpoint into new_season endpoint, add spec

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -19,6 +19,7 @@
 
 var express = require('express')
 ,   bodyParser = require('body-parser')
+,   _ = require('underscore')
 ,   mongoose = require('mongoose')
 ,   pluralize = require('pluralize')
 ,   request = require('request')
@@ -703,18 +704,19 @@ app.post('/', function(req, res){
             res.json({text: rankingString});
           });
           break;
-      case "reset":
+      case "new_season":
           var message = "";
-          if (hook.user_name === "vy") {
-            pong.findPlayer(params[2], function(user) {
-              if (user) {
-                pong.reset(params[2], function() {
-                  message = params[2] + "'s stats have been reset.";
-                  res.json({text: message});
-                });
-              } else if (user === false) {
-                message = "You're not registered! Use the command 'pongbot register' to get into the system.";
+          var secret = params[2];
+          if (hook.user_name === process.env.ADMIN_NAME && secret === process.env.ADMIN_SECRET) {
+            Player.find({}, function(err, players) {
+              if (err) return handleError(err);
+              var respond_after = _.after(players.length, function () {
+                message = "Welcome to the new season.";
                 res.json({text: message});
+              })
+              for (i = 0;i < players.length; i++) {
+                var user_name = players[i].user_name
+                pong.reset(user_name, respond_after);
               }
             });
           } else {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,14 @@
     "body-parser": "",
     "mongoose": "",
     "request": "",
-    "pluralize": ""
+    "pluralize": "",
+    "underscore": "~1.7.0"
   },
   "devDependencies": {
     "mocha": "",
-    "should": ""
+    "should": "",
+    "expect.js": "~0.3.1",
+    "superagent": "~0.19.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/test/lib/api.js
+++ b/test/lib/api.js
@@ -1,0 +1,81 @@
+var mongoose = require("mongoose");
+var pongbot = require("../../lib/app.js");
+var superagent = require('superagent')
+var expect = require('expect.js')
+var pong = pongbot.pong;
+var Player = pongbot.playerModel;
+
+describe('help', function(){
+  it('gets the help link', function(done){
+    superagent.post('http://localhost:3000/')
+      .send({
+        user_name: 'test',
+        text: 'pongbot help'
+      })
+      .end(function(e,res){
+        expect(res.body.text).to.eql('https://github.com/andrewvy/opal-pongbot')
+        done();
+      })
+  })
+})
+
+describe("new_season", function(){
+  var p2 = null;
+  beforeEach(function(done){
+    process.env.ADMIN_NAME = 'admin_name'
+    process.env.ADMIN_SECRET = 'admin_secret'
+
+    new Player({user_name: 'worst', wins: 0, losses: 2, elo: 0, tau: 0}).save();
+    p2 = new Player({user_name: 'middle', wins: 1, losses: 1, elo: 10, tau: 0});
+    p2.save();
+    new Player({user_name: 'best', wins: 2, losses: 0, elo: 20, tau: 0}).save();
+
+    done();
+  });
+
+  afterEach(function(done){ //delete all the player records
+    Player.remove({}, function() {
+      done();
+    });
+  });
+
+  it('clears all records when secret and user are correct', function(done){
+    superagent.post('http://localhost:3000/')
+      .send({
+        user_name: 'admin_name',
+        text: 'pongbot new_season admin_secret'
+      })
+      .end(function(e,res){
+        expect(res.body.text).to.eql('Welcome to the new season.')
+        Player.find({}).find( function(err, players) {
+          if (err) return handleError(err);
+          expect(players.length).to.eql(3);
+          for (var i=0;i<players.length;i++) {
+            expect(players[i].wins).to.eql(0);
+            expect(players[i].losses).to.eql(0);
+            expect(players[i].elo).to.eql(0);
+          }
+          done();
+        })
+      })
+  })
+
+  it('does not clear records when secret and user are incorrect', function(done){
+    superagent.post('http://localhost:3000/')
+      .send({
+        user_name: 'foo',
+        text: 'pongbot new_season bar'
+      })
+      .end(function(e,res){
+        expect(res.body.text).to.eql('You do not have admin rights.')
+        Player.where({user_name: p2.user_name}).findOne( function(err, user) {
+          if (err) return handleError(err);
+          expect(user.wins).to.eql(1);
+          expect(user.losses).to.eql(1);
+          expect(user.elo).to.eql(10);
+          done();
+        })
+      })
+  })
+});
+

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
 --require should
 --ui bdd
 --recursive
---timeout 30000
+--timeout 3000


### PR DESCRIPTION
This implements an admin like endpoint for clearing the leaderboard - as was recently necessary after very many games in the season.

Resetting the leaderboard both requires the user to be marked as an admin, and know the admin secret (something controlled by whoever is deploying).
